### PR TITLE
actionlib should use melodic-devel.

### DIFF
--- a/melodic/distribution.yaml
+++ b/melodic/distribution.yaml
@@ -60,7 +60,7 @@ repositories:
     doc:
       type: git
       url: https://github.com/ros/actionlib.git
-      version: indigo-devel
+      version: melodic-devel
     release:
       tags:
         release: release/melodic/{package}/{version}
@@ -70,7 +70,7 @@ repositories:
       test_pull_requests: true
       type: git
       url: https://github.com/ros/actionlib.git
-      version: indigo-devel
+      version: melodic-devel
     status: maintained
   adi_driver:
     doc:


### PR DESCRIPTION
There are some changes on `indigo-devel` which is not compatible with `melodic`, and we should update the `actionlib` upstream branch to avoid build break.