### PR TITLE
Adding missing keys & workaround openssl deps

### DIFF
--- a/rosdep/win-chocolatey.yaml
+++ b/rosdep/win-chocolatey.yaml
@@ -24,10 +24,20 @@ cppunit:
   windows: [cppunit]
 curl:
   windows: [libcurl]
+cyclonedds:
+  windows:
+    chocolatey:
+      depends: [openssl]
+      packages: []
 dfu-util:
   windows: [dfu-util]
 eigen:
   windows: [eigen]
+fastrtps:
+  windows:
+    chocolatey:
+      depends: [openssl, tinyxml2]
+      packages: []
 gazebo:
   windows: [gazebo9]
 gazebo9:

--- a/rosdep/win-chocolatey.yaml
+++ b/rosdep/win-chocolatey.yaml
@@ -564,6 +564,10 @@ python3-pytest:
   windows:
     pip:
       packages: [pytest]
+python3-pytest-mock:
+  windows:
+    pip:
+      packages: [pytest-mock]
 python3-qt5-bindings:
   windows:
     chocolatey:
@@ -583,6 +587,10 @@ python3-rosdep:
   windows:
     pip:
       packages: [rosdep]
+python3-rosdistro-modules:
+  windows:
+    pip:
+      packages: [rosdistro]
 python3-rospkg:
   windows:
     pip:

--- a/rosdep/win-chocolatey.yaml
+++ b/rosdep/win-chocolatey.yaml
@@ -494,6 +494,10 @@ python3-gnupg:
   windows:
     pip:
       packages: [gnupg]
+python3-ifcfg:
+  windows:
+    pip:
+      packages: [ifcfg]
 python3-pygraphviz:
   windows:
     pip:
@@ -502,6 +506,10 @@ python3-matplotlib:
   windows:
     pip:
       packages: [matplotlib]
+python3-mypy:
+  windows:
+    pip:
+      packages: [mypy]
 python3-lark-parser:
   windows:
     pip:

--- a/rosdep/win-chocolatey.yaml
+++ b/rosdep/win-chocolatey.yaml
@@ -173,6 +173,8 @@ libopenni-dev:
   windows: [OpenNI]
 libopenni2-dev:
   windows: [OpenNI2]
+libopensplice69:
+  windows: []
 liborocos-kdl-dev:
   windows: [orocos_kdl]
 liborocos-kdl:
@@ -602,6 +604,8 @@ qt5-qmake:
 qtbase5-dev:
   windows: [qt5-sdk]
 rsync:
+  windows: []
+rti-connext-dds-5.3.1:
   windows: []
 sbcl:
   windows: [sbcl]


### PR DESCRIPTION
* Adding missing keys: `python3-mypy`, `python3-pytest-mock`, `python3-rosdistro-modules`, `python3-ifcfg`.

* Adding `openssl` deps on behave of `cyclonedds` and `fastrtps`, which are served as a workaround. We need to figure out why their `package.xml` are not in the binary installation.